### PR TITLE
Avoid deprecated/removed `Dir.exists?` method for Ruby 3.2 compatibility

### DIFF
--- a/lib/slither.rb
+++ b/lib/slither.rb
@@ -48,7 +48,7 @@ module Slither
   end
 
   def self.parse(filename, definition_name)
-    raise ArgumentError, "File #{filename} does not exist." unless File.exists?(filename)
+    raise ArgumentError, "File #{filename} does not exist." unless File.exist?(filename)
 
     file_io = File.open(filename, 'r')
     parseIo(file_io, definition_name)

--- a/spec/slither_spec.rb
+++ b/spec/slither_spec.rb
@@ -70,10 +70,6 @@ RSpec.describe Slither do
     end
 
     context "when the file is found" do
-      before do
-        allow(File).to receive(:exists?).and_return(true)
-      end
-
       context "and the definition is not found" do
         it "raises an error due to the definition name not being found" do
           expect do


### PR DESCRIPTION
Removed in Ruby 3.2:
https://rubyreferences.github.io/rubychanges/3.2.html#removals

I removed the test method stub that hides the removal causing a false-positive test pass on Ruby 3.2